### PR TITLE
Add linux build support + audio handing into helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To build a ``BAPSicle.exe``, run ``build\build-exe.bat``. The resulting file wil
 
 ### Linux
 
-Coming soon...
+To build a ``BAPSicle`` executable, run ``build/build-linux.sh``. The resulting file will appear in ``build/output``.
 
 ### MacOS
 

--- a/build/build-linux.sh
+++ b/build/build-linux.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+
+apt install libportaudio2
+
+pip3 install -r requirements.txt
+pip3 install -r requirements-linux.txt
+pip3 install -e ..\
+
+python3 ./generate-build-exe-config.py
+
+python3 ./build-exe.py
+
+bash ./build-exe-pyinstaller-command.sh
+
+rm ./*.spec
+

--- a/build/requirements-linux.txt
+++ b/build/requirements-linux.txt
@@ -1,0 +1,1 @@
+pyinstaller

--- a/helpers/device_manager.py
+++ b/helpers/device_manager.py
@@ -1,0 +1,27 @@
+import sounddevice as sd
+import importlib
+from os_environment import isMacOS
+
+class DeviceManager():
+
+  @classmethod
+  def _isOutput(self, device):
+    return device["max_output_channels"] > 0
+
+  @classmethod
+  def _getDevices(self):
+    # To update the list of devices
+    # Sadly this doesn't work on MacOS.
+    if not isMacOS():
+      sd._terminate()
+      sd._initialize()
+    devices = sd.query_devices()
+    return devices
+
+  @classmethod
+  def getOutputs(self):
+    outputs = filter(self._isOutput, self._getDevices())
+
+    return outputs
+
+  # TODO: Maybe some hotplug event triggers support for the players?

--- a/helpers/device_manager.py
+++ b/helpers/device_manager.py
@@ -1,27 +1,28 @@
 import sounddevice as sd
 import importlib
-from os_environment import isMacOS
+from helpers.os_environment import isMacOS
+
 
 class DeviceManager():
 
-  @classmethod
-  def _isOutput(self, device):
-    return device["max_output_channels"] > 0
+    @classmethod
+    def _isOutput(self, device):
+        return device["max_output_channels"] > 0
 
-  @classmethod
-  def _getDevices(self):
-    # To update the list of devices
-    # Sadly this doesn't work on MacOS.
-    if not isMacOS():
-      sd._terminate()
-      sd._initialize()
-    devices = sd.query_devices()
-    return devices
+    @classmethod
+    def _getDevices(self):
+        # To update the list of devices
+        # Sadly this doesn't work on MacOS.
+        if not isMacOS():
+            sd._terminate()
+            sd._initialize()
+        devices = sd.query_devices()
+        return devices
 
-  @classmethod
-  def getOutputs(self):
-    outputs = filter(self._isOutput, self._getDevices())
+    @classmethod
+    def getOutputs(self):
+        outputs = filter(self._isOutput, self._getDevices())
 
-    return outputs
+        return outputs
 
-  # TODO: Maybe some hotplug event triggers support for the players?
+    # TODO: Maybe some hotplug event triggers support for the players?

--- a/helpers/device_manager.py
+++ b/helpers/device_manager.py
@@ -24,5 +24,3 @@ class DeviceManager():
         outputs = filter(self._isOutput, self._getDevices())
 
         return outputs
-
-    # TODO: Maybe some hotplug event triggers support for the players?

--- a/server.py
+++ b/server.py
@@ -2,10 +2,10 @@ import multiprocessing
 import player
 from flask import Flask, render_template, send_from_directory, request
 import json
-import sounddevice as sd
 import setproctitle
 import logging
 from helpers.os_environment import isMacOS
+from helpers.device_manager import DeviceManager
 
 setproctitle.setproctitle("BAPSicle - Server")
 
@@ -55,12 +55,7 @@ def ui_config():
     for i in range(3):
         channel_states.append(status(i))
 
-    devices = sd.query_devices()
-    outputs = []
-
-    for device in devices:
-        if device["max_output_channels"] > 0:
-            outputs.append(device)
+    outputs = DeviceManager.getOutputs()
 
     data = {
         'channels': channel_states,


### PR DESCRIPTION
The audio shuffle also brings support for changing hardware devices during runtime. PortAudio for MacOS seems to fall over doing that, so it's disabled for now.