### PR TITLE
3.0.1 Minor Patch for Audio Reliability

### DIFF
--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,7 +1,7 @@
 autopep8
 pygame==2.0.1
-sanic
-sanic-cors
+sanic==21.3.4
+sanic-Cors==1.0.0
 syncer
 aiohttp
 mutagen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "bapsicle",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bapsicle",
   "nice_name": "BAPSicle",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "BAPS3, the third generation of University Radio York's Broadcast and Presenting Suite. This package includes the Server (BAPSicle) and Presenter (WebStudio)",
   "main": "index.js",
   "directories": {

--- a/player.py
+++ b/player.py
@@ -394,9 +394,13 @@ class Player:
 
     def load(self, weight: int):
         if not self.isPlaying:
+            loaded_state = self.state.get()
             self.unload()
 
-            showplan = self.state.get()["show_plan"]
+            self.logger.log.info("Resetting output (in case of sound output gone silent somehow) to " + str(loaded_state["output"]))
+            self.output(loaded_state["output"])
+
+            showplan = loaded_state["show_plan"]
 
             loaded_item: Optional[PlanItem] = None
 

--- a/web_server.py
+++ b/web_server.py
@@ -319,9 +319,15 @@ async def audio_file(request, type: str, id: int):
 # Static Files
 app.static("/favicon.ico", resolve_local_file_path("ui-static/favicon.ico"), name="ui-favicon")
 app.static("/static", resolve_local_file_path("ui-static"), name="ui-static")
-app.static("/presenter/", resolve_local_file_path("presenter-build/index.html"),
-           strict_slashes=True, name="presenter-index")
-app.static("/presenter/", resolve_local_file_path("presenter-build"))
+
+dist_directory = resolve_local_file_path("presenter-build")
+app.static("/presenter", dist_directory)
+app.static(
+    "/presenter/",
+    resolve_local_file_path("presenter-build/index.html"),
+    strict_slashes=True,
+    name="presenter-index",
+)
 
 
 # Helper Functions

--- a/websocket_server.py
+++ b/websocket_server.py
@@ -7,7 +7,7 @@ from typing import List
 import websockets
 import json
 from os import _exit
-from websockets.server import Serve
+from websockets.server import serve
 from setproctitle import setproctitle
 from multiprocessing import current_process
 
@@ -25,7 +25,7 @@ class WebsocketServer:
     logger: LoggingManager
     to_webstudio: Task
     from_webstudio: Task
-    websocket_server: Serve
+    websocket_server: serve
 
     def __init__(self, in_q, out_q, state):
 


### PR DESCRIPTION
Now that studio usage has risen back to its prime, issues are being seen with BAPSicle.

Specifically seen on Windows, potentially related to changing sound devices when monitors etc turn on and off in the studios, BAPS channels can go silent.

This issue is fixed by automatically re-initialising the audio device on item load. This is deemed suitable because:

- When someone turns the studio on to start their show, they will load their own new show plan items
- Typically, if something doesn't play, they are likely to try reloading it and trying again
- The manual equivalent of this is a known successful mitigation.

Given some more work is required for stability of the current dev branch for 3.1, i'm making a minor patch for this in the interim.

Also required was a patch to the web server, since the previous incantation of serving the presenter was flaky on different platforms.