### PR TITLE
Poetry setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Starting and stopping the server, as well as UI links, are available in the Syst
 On all platforms:
 
 -   Python 3.8 - 3.11 Tested
+-   [Poetry](https://python-poetry.org/)
 -   Git (Obviously)
 
 On MacOS:
@@ -47,7 +48,9 @@ On MacOS:
 
 ### Running
 
-To just run the server standalone without installing, run `python ./launch.py`.
+To run the server standalone without installing BAPSicle, you'll need to install the dependencies.
+Run `poetry install` in the root directory to install them.
+Then, run `poetry run python ./launch.py` to start the server.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ On MacOS:
 
 To run the server standalone without installing BAPSicle, you'll need to install the dependencies.
 Run `poetry install` in the root directory to install them.
+BAPSicle also requires a built version of the [presenter UI](https://github.com/UniversityRadioYork/WebStudio) in order to use; run `npm run presenter-make` to build it (the output will be in `presenter-ui`/).
 Then, run `poetry run python ./launch.py` to start the server.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ On all platforms:
 
 -   Python 3.8 - 3.11 Tested
 -   [Poetry](https://python-poetry.org/)
+-   NodeJS and Yarn 1.x
 -   Git (Obviously)
 
 On MacOS:


### PR DESCRIPTION
When the migration was made to poetry the setup instructions in the readme were not update to reflect that change.

I've tried my best to do that having never used poetry before lmao if u can make sure these are what you expected before merge BCS I can't fully test this I have an (I assume) unrelated bug.

kthxxx