### PR TITLE
action bump v2 to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,16 +50,16 @@ jobs:
         node-version: ['20']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup poetry
       uses: Gr1N/setup-poetry@v8
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Build executable
@@ -88,14 +88,14 @@ jobs:
         node-version: ['20']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup poetry
       uses: Gr1N/setup-poetry@v8
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Node ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,9 @@ jobs:
         python-version: [3.8, 3.9, 3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup poetry


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest versions of the actions. The main changes involve upgrading the versions of `actions/checkout`, `actions/setup-python`, and `actions/setup-node` in the build and test workflows.

Updates to GitHub Actions:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L53-R62): Updated `actions/checkout` from v2 to v4, `actions/setup-python` from v2 to v4, and `actions/setup-node` from v2 to v4. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L53-R62) [[2]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L91-R98)
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L16-R18): Updated `actions/checkout` from v2 to v4, and `actions/setup-python` from v2 to v4.

![394520608-97364294-844e-461a-8635-d6dcecd219a0](https://github.com/user-attachments/assets/a7bdbadf-ea38-4f8a-a277-c40f3902e494)

